### PR TITLE
chore: fix path typo on workflow file

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -38,7 +38,7 @@ jobs:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           password: ${{ secrets.PASSWORD }}
-          source: badging.tar
+          source: badging-staging.tar
           target: ~/
 
       - name: Extract and load image on droplet


### PR DESCRIPTION
**Summary:**

Fixes a typography in the workflow file for staging deployment

**Changes:**

.github/workflows/deploy-staging.yml

**Testing:**

Check the GitHub action tab and check the action logs

**Additional Notes:**
None
